### PR TITLE
Securities tests under engagement

### DIFF
--- a/models/results.py
+++ b/models/results.py
@@ -21,6 +21,9 @@ class SecurityResultsDAST(db_tools.AbstractBaseMixin, db.Base, rpc_tools.RpcMixi
     # TODO: excluded = ignored
     id = Column(Integer, primary_key=True)
     project_id = Column(Integer, unique=False, nullable=False)
+    # engagement it belongs to 
+    engagement = Column(String(64), nullable=True, default=None)
+    #
     test_id = Column(Integer, unique=False)
     test_uid = Column(String(128), unique=False)
     test_name = Column(String(128), unique=False)
@@ -53,6 +56,7 @@ class SecurityResultsDAST(db_tools.AbstractBaseMixin, db.Base, rpc_tools.RpcMixi
     # other
     # excluded = Column(Integer, unique=False)
     tags = Column(ARRAY(String), default=[])
+
     test_status = Column(
         JSON,
         default={

--- a/static/js/app/main.js
+++ b/static/js/app/main.js
@@ -174,6 +174,19 @@ var apiActions = {
 
 }
 
+function testQueryParams(params){
+    const urlSearchParams = new URLSearchParams(window.location.search);
+    const currentParams = Object.fromEntries(urlSearchParams.entries());
+    params['filter'] = JSON.stringify({'test_uid': currentParams['test_uid']})
+    return params
+}
+
+function testResultsqueryParams(params){
+    const urlSearchParams = new URLSearchParams(window.location.search);
+    const currentParams = Object.fromEntries(urlSearchParams.entries());
+    params['filter'] = JSON.stringify(currentParams)
+    return params
+}
 
 $(document).on('vue_init', () => {
     $('#delete_test').on('click', e => {

--- a/templates/app/content.html
+++ b/templates/app/content.html
@@ -2,16 +2,17 @@
     <div class="flex-container">
         <div class="flex-item-2">
             <Table-Card
-                    @register="register"
-                    instance_name="table_tests"
+                @register="register"
+                instance_name="table_tests"
 
-                    header='Application Tests'
-                    :table_attributes="{
-                        'data-url': '/api/v1/security/tests/{{ tools.session_project.get() }}',
-                        'data-page-size': 5,
-                        id: 'application_tests_table'
-                    }"
-                    container_classes="h-100"
+                header='Application Tests'
+                :table_attributes="{
+                    'data-url': '/api/v1/security/tests/{{ tools.session_project.get() }}',
+                    'data-page-size': 5,
+                    id: 'application_tests_table',
+                    'data-query-params': 'testQueryParams'
+                }"
+                container_classes="h-100"
             >
                 <template #actions>
                     <div class="d-flex justify-content-end">
@@ -97,7 +98,8 @@
             {#            :borders="true"#}
             :table_attributes="{
                 'data-url': '/api/v1/security/results/{{ tools.session_project.get() }}',
-                id: 'results_table'
+                id: 'results_table',
+                'data-query-params': 'testResultsqueryParams'
             }"
             container_classes="mt-3"
     >

--- a/utils.py
+++ b/utils.py
@@ -11,7 +11,7 @@ from .models.results import SecurityResultsDAST
 from tools import rpc_tools, task_tools
 
 
-def run_test(test: SecurityTestsDAST, config_only=False) -> dict:
+def run_test(test: SecurityTestsDAST, config_only=False, engagement_id=None) -> dict:
     results = SecurityResultsDAST(
         project_id=test.project_id,
         test_id=test.id,

--- a/utils.py
+++ b/utils.py
@@ -11,12 +11,15 @@ from .models.results import SecurityResultsDAST
 from tools import rpc_tools, task_tools
 
 
-def run_test(test: SecurityTestsDAST, config_only=False, engagement_id=None) -> dict:
+def run_test(test: SecurityTestsDAST, config_only=False) -> dict:
+    engagement_id = test.integrations.get('reporters', {}).get('reporter_engagement')
+
     results = SecurityResultsDAST(
         project_id=test.project_id,
         test_id=test.id,
         test_uid=test.test_uid,
-        test_name=test.name
+        test_name=test.name,
+        engagement=engagement_id
     )
     results.insert()
 


### PR DESCRIPTION
Changes:

1. Engagement field is added to the test result model
2. Support for **engagement_id** query parameter in the "/-/security/app/" page to show only test results related to that engagement
3. run_tests methods changed to include engagement_id value into test result
